### PR TITLE
Add --skip-if-outputdir-exists flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ This extension aims to provide a clean implementation that tries to avoid
 messing with Sphinx internals as much as possible.
 
 Documentation can be found at: https://holzhaus.github.io/sphinx-multiversion/
+
+---
+
+This is a fork of the original `sphinx-multiversion`. The fork was made at version `0.2.4`, and all newer versions 
+represent new features and bug fixes. See `docs/changelog.rst` for details.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,34 @@ Changelog
 Version 0.2
 ===========
 
+Version 0.2.9 (2023-01-05)
+--------------------------
+* Skip a build when output directory exists with flag ``--skip-if-outputdir-exists``.
+
+
+Version 0.2.8 (2022-07-20)
+--------------------------
+* Build development version of docs from current directory with ``--dev-name`` and ``--dev-path``.
+
+
+Version 0.2.7 (2022-07-20)
+--------------------------
+* Detect latest release, generate HTML redirection page.
+
+
+Version 0.2.6 (2022-06-10)
+--------------------------
+* Keep track of released versions
+* Pass `smv_latest_version` explicitly when calling Sphinx builder.
+* Generate a HTML page which redirects to the latest version of docs.
+
+
+Version 0.2.5 (2022-06-10)
+--------------------------
+* The original repo seems to be no longer maintained. There were new commits since the latest release `0.2.4`; this release includes all of them.
+* When reading metadata from `conf.py`, value `release` is now set to the name of git reference point.
+
+
 Version 0.2.4 (2020-08-12)
 --------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ import time
 
 author = "Jan Holthuis"
 project = "sphinx-multiversion"
-release = "0.2.4"
+release = "0.2.9"
 version = "0.2"
 copyright = "{}, {}".format(time.strftime("%Y"), author)
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -61,6 +61,7 @@ In addition, sphinx-multiversion can build the development version of the docs f
 
 By default, the development version of the docs is stored in the root build directory. You can change this by providing a path relative to the root build directory using the ``--dev-path`` option. For example, ``--dev-path dev/current`` will build the development version in ``dev/current`` subdirectory inside the root build directory.
 
+
 Release Pattern
 ===============
 
@@ -107,6 +108,11 @@ Here are some examples:
 .. seealso::
 
     Have a look at `PyFormat <python_format_>`_ for information how to use new-style Python formatting.
+
+Skipping Build
+==============
+
+Building docs for a specific version can be skipped if the target directory already exists and ``--skip-if-outputdir-exists`` flag is passed to `sphinx-multiversion`. It does not check the contents of the directory, only its existence. This can be used to speed up the whole process, so that the docs for older versions are not rebuilt every time.
 
 
 Overriding Configuration Variables

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -175,6 +175,11 @@ def main(argv=None):
         help="dump generated metadata and exit",
     )
     parser.add_argument(
+        "--skip-if-outputdir-exists",
+        action="store_true",
+        help="skip building version if its output directory exists",
+    )
+    parser.add_argument(
         "--dev-name",
         metavar="DEV_NAME",
         dest="dev_name",
@@ -366,6 +371,17 @@ def main(argv=None):
         # Run Sphinx
         argv.extend(["-D", "smv_metadata_path={}".format(metadata_path)])
         for version_name, data in metadata.items():
+            # When --skip-if-outputdir-exists flag passed, do not build version if its output
+            # directory already exists. This does not check the contents of directory.
+            if args.skip_if_outputdir_exists:
+                if os.path.isdir(data['outputdir']) and data['name'] != args.dev_name:
+                    logger.warning(
+                        "Skipping version because outputdir '%s' for %s already exists",
+                        data['outputdir'],
+                        data['name'],
+                    )
+                    continue
+
             os.makedirs(data["outputdir"], exist_ok=True)
 
             defines = itertools.chain(


### PR DESCRIPTION
Building docs for a specific version can be skipped if the target directory already exists and ``--skip-if-outputdir-exists`` flag is passed to `sphinx-multiversion`. It does not check the contents of the directory, only its existence. This can be used to speed up the whole process, so that the docs for older versions are not rebuilt every time.