### PR TITLE
Reduce docs size in a different way

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ Changelog
 Version 0.2
 ===========
 
+Version 0.2.12 (2023-02-08)
+--------------------------
+* Reduce docs size.
+
+
 Version 0.2.11 (2023-02-02)
 --------------------------
 * Reduce docs size.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ Changelog
 Version 0.2
 ===========
 
+Version 0.2.11 (2023-02-02)
+--------------------------
+* Reduce docs size.
+
+
 Version 0.2.10 (2023-01-13)
 --------------------------
 * Try extracting the version from the git tag if it exists and sort based on that. Clients can configure an optional ``smv_symver_pattern`` if default patter is not suitable.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ import time
 
 author = "Jan Holthuis"
 project = "sphinx-multiversion"
-release = "0.2.11"
+release = "0.2.12"
 version = "0.2"
 copyright = "{}, {}".format(time.strftime("%Y"), author)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ import time
 
 author = "Jan Holthuis"
 project = "sphinx-multiversion"
-release = "0.2.10"
+release = "0.2.11"
 version = "0.2"
 copyright = "{}, {}".format(time.strftime("%Y"), author)
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author="Jan Holthuis",
     author_email="holthuis.jan@googlemail.com",
     url="https://github.com/iqm-finland/sphinx-multiversion-contrib",
-    version="0.2.11",
+    version="0.2.12",
     install_requires=["sphinx >= 2.1"],
     license="BSD",
     packages=["sphinx_multiversion"],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author="Jan Holthuis",
     author_email="holthuis.jan@googlemail.com",
     url="https://github.com/iqm-finland/sphinx-multiversion-contrib",
-    version="0.2.10",
+    version="0.2.11",
     install_requires=["sphinx >= 2.1"],
     license="BSD",
     packages=["sphinx_multiversion"],

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -261,7 +261,10 @@ def main(argv=None):
     logger = logging.getLogger(__name__)
     released_versions = []
 
-    with tempfile.TemporaryDirectory() as tmp:
+    with (
+        tempfile.TemporaryDirectory() as tmp,
+        tempfile.TemporaryDirectory() as doctree_cache
+    ):
         # Generate Metadata
         metadata = {}
         outputdirs = set()
@@ -416,6 +419,8 @@ def main(argv=None):
                 *get_python_flags(),
                 "-m",
                 "sphinx",
+                "-d",
+                doctree_cache,
                 *current_argv,
             )
             current_cwd = os.path.join(data["basedir"], cwd_relative)

--- a/sphinx_multiversion/main.py
+++ b/sphinx_multiversion/main.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import datetime
+import filecmp
 
 from sphinx import config as sphinx_config
 from sphinx import project as sphinx_project
@@ -436,5 +437,21 @@ def main(argv=None):
                 }
             )
             subprocess.check_call(cmd, cwd=current_cwd, env=env)
+
+    # check if there are any files in the versioned output directories identical to files in the root dev output directory and replace them with symlinks
+    if args.dev_name:
+        dev_outputdir = metadata[args.dev_name]['outputdir']
+        for version_name, data in metadata.items():
+            if version_name == args.dev_name:
+                continue
+            version_outputdir = data['outputdir']
+            for root, dirs, files in os.walk(version_outputdir):
+                for file in files:
+                    dev_file_path = os.path.join(dev_outputdir, os.path.relpath(root, version_outputdir), file)
+                    # check files are identical
+                    if os.path.exists(dev_file_path) and filecmp.cmp(os.path.join(root, file), dev_file_path):
+                        version_file_path = os.path.join(root, file)
+                        os.remove(version_file_path)
+                        os.symlink(dev_file_path, version_file_path)
 
     return 0


### PR DESCRIPTION
While symlinks approach is clever, it is not a reliable way, not only because of windows, but for example because of GitHub actions. The new approach actually changes links to `_static` folder from version to the `dev` version.