### PR TITLE
Reduce generated docs size, but in a different way

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ Changelog
 Version 0.2
 ===========
 
+Version 0.2.12 (2023-02-08)
+--------------------------
+* Reduce docs size.
+
+
 Version 0.2.11 (2023-02-02)
 --------------------------
 * Reduce docs size.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ import time
 
 author = "Jan Holthuis"
 project = "sphinx-multiversion"
-release = "0.2.11"
+release = "0.2.12"
 version = "0.2"
 copyright = "{}, {}".format(time.strftime("%Y"), author)
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author="Jan Holthuis",
     author_email="holthuis.jan@googlemail.com",
     url="https://github.com/iqm-finland/sphinx-multiversion-contrib",
-    version="0.2.11",
+    version="0.2.12",
     install_requires=["sphinx >= 2.1"],
     license="BSD",
     packages=["sphinx_multiversion"],


### PR DESCRIPTION
While symlinks approach is clever, it is not a reliable way, not only because of windows, but for example because of GitHub actions. The new approach actually changes links to _static folder from version to the dev version.